### PR TITLE
Make Applications icon optional.

### DIFF
--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -105,7 +105,6 @@ module.exports = exports = function (source, target, cb) {
     if (global.opts.icons) {
       check(global.opts.icons, 'size', 'icons.size');
       check(global.opts.icons, 'app', 'icons.app');
-      check(global.opts.icons, 'alias', 'icons.alias');
     }
 
     if (missing.length > 0) {
@@ -291,11 +290,12 @@ module.exports = exports = function (source, target, cb) {
    **/
 
   pipeline.addStep('Creating Applications alias', function (next) {
-
-    var finalPath = path.join(global.temporaryMountPath, 'Applications');
-
-    fs.symlink('/Applications', finalPath, function (err) { next(err); });
-
+    if (global.opts.icons.alias) {
+      var finalPath = path.join(global.temporaryMountPath, 'Applications');
+      fs.symlink('/Applications', finalPath, function (err) { next(err); });
+    } else {
+      next.skip();
+    }
   });
 
   /**
@@ -328,7 +328,9 @@ module.exports = exports = function (source, target, cb) {
     ds.setBackground(path.join(global.temporaryMountPath, global.bkgname));
     ds.setWindowSize(global.bkgsize[0], global.bkgsize[1]);
 
-    ds.setIconPos('Applications', global.opts.icons.alias[0], global.opts.icons.alias[1]);
+    if (global.opts.icons.alias) {
+      ds.setIconPos('Applications', global.opts.icons.alias[0], global.opts.icons.alias[1]);
+    }
 
     global.files.forEach(function (e) {
       ds.setIconPos(path.basename(e[0]), e[1], e[2]);


### PR DESCRIPTION
While it makes sense for DMGs containing .app bundles to have a link to
/Applications, those aren't the only kind of DMGs. Make the Applications
icon optional so that DMGs containing something like a .pkg bundle can
be created.
