### PR TITLE
Specify supported operating system

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
+  "os": ["darwin"],
   "repository": {
     "type": "git",
     "url": "http://github.com/LinusU/node-appdmg.git"


### PR DESCRIPTION
This generates much nicer error when trying to install on operating systems other than OSX:

Before it was:
```
make: Entering directory `/home/kuba/tmp/node_modules/appdmg/node_modules/fs-xattr/build'
  CXX(target) Release/obj.target/xattr/src/xattr.o
  SOLINK_MODULE(target) Release/obj.target/xattr.node
  SOLINK_MODULE(target) Release/obj.target/xattr.node: Finished
  COPY Release/xattr.node
make: Leaving directory `/home/kuba/tmp/node_modules/appdmg/node_modules/fs-xattr/build'
 
> macos-alias@0.2.6 install /home/kuba/tmp/node_modules/appdmg/node_modules/ds-store/node_modules/macos-alias
> node-gyp rebuild

make: Entering directory `/home/kuba/tmp/node_modules/appdmg/node_modules/ds-store/node_modules/macos-alias/build'
  CXX(target) Release/obj.target/volume/src/volume.o
../src/volume.cc:9:2: error: #error This platform is not implemented yet
 #error This platform is not implemented yet
  ^
../src/volume.cc: In function ‘void Initialize(v8::Handle<v8::Object>)’:
../src/volume.cc:15:66: error: ‘MethodGetVolumeName’ was not declared in this scope
   exports->Set(NanNew("getVolumeName"), NanNew<FunctionTemplate>(MethodGetVolumeName)->GetFunction());
                                                                  ^
make: *** [Release/obj.target/volume/src/volume.o] Error 1
make: Leaving directory `/home/kuba/tmp/node_modules/appdmg/node_modules/ds-store/node_modules/macos-alias/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:267:23)
gyp ERR! stack     at ChildProcess.emit (events.js:98:17)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (child_process.js:820:12)
gyp ERR! System Linux 3.13.0-49-generic
gyp ERR! command "node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/kuba/tmp/node_modules/appdmg/node_modules/ds-store/node_modules/macos-alias
gyp ERR! node -v v0.10.37
gyp ERR! node-gyp -v v1.0.1
gyp ERR! not ok 
```

Now it is:
```
npm ERR! notsup Unsupported
npm ERR! notsup Not compatible with your operating system or architecture: appdmg@0.3.0
npm ERR! notsup Valid OS:    darwin
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   linux
npm ERR! notsup Actual Arch: x64
```