### PR TITLE
Remove duplicate fs-temp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "capture-window": "^0.1.3",
-    "fs-temp": "^1.0.0",
     "looks-same": "^2.1.0",
     "mocha": "^2.2.5",
     "standard": "^5.1.0"


### PR DESCRIPTION
When running `npm install`, a warning comes up:

```
npm WARN package.json Dependency 'fs-temp' exists in both dependencies and devDependencies, using 'fs-temp@^1.0.0' from dependencies
```