### PR TITLE
add compression option

### DIFF
--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -120,6 +120,7 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Validating JSON Specification', function (next) {
+    // MISSING
     var missing = []
     var check = function (root, key, title) {
       if (!root[key]) missing.push(title || key)
@@ -137,8 +138,24 @@ module.exports = exports = function (options) {
       check(entry, 'path', 'contents.' + i + '.path')
     })
 
+    // INVALID
+    var invalid = []
+    var checkValid = function(root, key, whitelist, title) {
+      if (whitelist.indexOf(root[key]) === -1) {
+        var errorReference = title || key;
+        invalid.push('`' + errorReference + '` is invalid. Valid values are: ' +
+                     '[' + whitelist.join('`,`') + '].')
+      }
+    }
+
+    if (global.opts.compression) {
+      checkValid(global.opts, 'compression', ['UDBZ', 'UDZO', 'NONE'])
+    }
+
     if (missing.length > 0) {
       next(new Error('`' + (missing.join('`,`')) + '` missing from JSON Specification'))
+    } else if (invalid.length > 0) {
+      next(new Error(invalid.join("\n")))
     } else {
       next(null)
     }
@@ -390,7 +407,8 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Finalizing image', function (next) {
-    hdiutil.convert(global.temporaryImagePath, global.target, next)
+    var format = global.opts.compression || 'UDZO';
+    hdiutil.convert(global.temporaryImagePath, format, global.target, next)
   })
 
   /**

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -2,10 +2,10 @@ var fs = require('fs')
 var temp = require('fs-temp')
 var util = require('./util')
 
-exports.convert = function (source, target, cb) {
+exports.convert = function (source, format, target, cb) {
   var args = []
   args.push('convert', source)
-  args.push('-format', 'UDZO')
+  args.push('-format', format)
   args.push('-imagekey', 'zlib-level=9')
   args.push('-o', target)
   util.sh('hdiutil', args, function (err) {


### PR DESCRIPTION
As outlined in #54, this implements bzip2 compression, including adding a global option.

I didn't find any code to verify that options were valid, so I implemented a function similar to check called checkValid, which checks against a whitelist.

It currently also implicitly allows the option to not be present (undefined), and falls back to the old behaviour.

I could revise this if there are any concerns about the implementation details.

I also am unsure about how to test this. I'm not regularly programming with node, so after running "npm install", I got an error when trying to run the tests directory.