### PR TITLE
support "position" value for "type" field

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -80,7 +80,8 @@
             "type": "string",
             "enum": [
               "link",
-              "file"
+              "file",
+              "position"
             ]
           },
           "path": {

--- a/test/assets/appdmg.json
+++ b/test/assets/appdmg.json
@@ -7,6 +7,6 @@
     { "x": 448, "y": 344, "type": "link", "path": "/Applications" },
     { "x": 192, "y": 344, "type": "file", "path": "TestApp.app" },
     { "x": 512, "y": 128, "type": "file", "path": "TestDoc.txt" },
-    { "x": 512, "y": 900, "type": "position", "path": ".Volumeicon.icns" }
+    { "x": 512, "y": 900, "type": "position", "path": ".VolumeIcon.icns" }
   ]
 }

--- a/test/assets/appdmg.json
+++ b/test/assets/appdmg.json
@@ -6,6 +6,7 @@
   "contents": [
     { "x": 448, "y": 344, "type": "link", "path": "/Applications" },
     { "x": 192, "y": 344, "type": "file", "path": "TestApp.app" },
-    { "x": 512, "y": 128, "type": "file", "path": "TestDoc.txt" }
+    { "x": 512, "y": 128, "type": "file", "path": "TestDoc.txt" },
+    { "x": 512, "y": 900, "type": "position", "path": ".Volumeicon.icns" }
   ]
 }


### PR DESCRIPTION
  This makes it possible to position hidden folders out of
  the initial dmg Finder window.  see the following discussion
  https://github.com/LinusU/node-appdmg/issues/45

  This change adds "position" to the enum list for the "type" field
  in the "contents" array objects