### PR TITLE
Add support for signing the resulting DMG

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ the JSON file's path.
         + `position` - Positions a present file
     + `path` (string, required) - Path to the file
     + `name` (string, optional) - Name of the file within the DMG
++ `code-sign-identity` (string, optional) - The identity with which to sign the resulting DMG
 
 `0.1.x` used a different JSON format. This format is still supported but
 deprecated, please update your json.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ the JSON file's path.
         + `position` - Positions a present file
     + `path` (string, required) - Path to the file
     + `name` (string, optional) - Name of the file within the DMG
-+ `code-sign-identity` (string, optional) - The identity with which to sign the resulting DMG
++ `code-sign` (object, optional) - Options for codesigning the DMG
+  + `signing-identity` (string, required) - The identity with which to sign the resulting DMG
+  + `identifier` (string, optional) - Explicitly set the unique identifier string that is embedded in code signatures
 
 `0.1.x` used a different JSON format. This format is still supported but
 deprecated, please update your json.

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -420,6 +420,20 @@ module.exports = exports = function (options) {
    **
    **/
 
+  pipeline.addStep('Signing image', function (next) {
+    var codeSignIdentity = global.opts['code-sign-identity']
+
+    if (codeSignIdentity) {
+      util.codesign(codeSignIdentity, global.target, next)
+    } else {
+      return next.skip()
+    }
+  })
+
+  /**
+   **
+   **/
+
   pipeline.expectAdditional(1)
 
   return pipeline.run()

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -421,12 +421,13 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Signing image', function (next) {
-    var codeSignIdentity = global.opts['code-sign-identity']
-
-    if (codeSignIdentity) {
-      util.codesign(codeSignIdentity, global.target, next)
+    var codeSignOptions = global.opts['code-sign']
+    if (codeSignOptions && codeSignOptions['signing-identity']) {
+      var codeSignIdentity = codeSignOptions['signing-identity']
+      var codeSignIdentifier = codeSignOptions['identifier']
+      util.codesign(codeSignIdentity, codeSignIdentifier, global.target, next)
     } else {
-      return next.skip()
+      return next.step()
     }
   })
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -47,6 +47,11 @@ exports.seticonflag = function (path, cb) {
   xattr.set(path, 'com.apple.FinderInfo', buf, cb)
 }
 
-exports.codesign = function (identity, path, cb) {
-  exports.sh('codesign', ['--verbose', '--sign', identity, path], function (err) { cb(err) })
+exports.codesign = function (identity, identifier, path, cb) {
+  var args = ['--verbose', '--sign', identity]
+  if (identifier) {
+    args.push('--identifier', identifier)
+  }
+  args.push(path)
+  exports.sh('codesign', args, function (err) { cb(err) })
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -46,3 +46,7 @@ exports.seticonflag = function (path, cb) {
   buf.writeUInt8(4, 8)
   xattr.set(path, 'com.apple.FinderInfo', buf, cb)
 }
+
+exports.codesign = function (identity, path, cb) {
+  exports.sh('codesign', ['--verbose', '--force', '--sign', identity, path], function (err) { cb(err) })
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -48,5 +48,5 @@ exports.seticonflag = function (path, cb) {
 }
 
 exports.codesign = function (identity, path, cb) {
-  exports.sh('codesign', ['--verbose', '--force', '--sign', identity, path], function (err) { cb(err) })
+  exports.sh('codesign', ['--verbose', '--sign', identity, path], function (err) { cb(err) })
 }

--- a/schema.json
+++ b/schema.json
@@ -98,6 +98,9 @@
           "path"
         ]
       }
+    },
+    "code-sign-identity": {
+      "type": "string"
     }
   },
   "required": [

--- a/schema.json
+++ b/schema.json
@@ -99,8 +99,19 @@
         ]
       }
     },
-    "code-sign-identity": {
-      "type": "string"
+    "code-sign": {
+      "type": "object",
+      "properties": {
+        "signing-identity": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "signing-identity"
+      ]
     }
   },
   "required": [

--- a/test/api.js
+++ b/test/api.js
@@ -9,7 +9,7 @@ var path = require('path')
 var temp = require('fs-temp')
 var assert = require('assert')
 
-var STEPS = 20
+var STEPS = 21
 
 function runAppdmg (opts, verify, cb) {
   var progressCalled = 0


### PR DESCRIPTION
DMGs should ideally be signed when they're distributed: https://sparkle-project.org/documentation/#4-distributing-your-app (#134)

I'm not sure if there's a good way to test this.