### PR TITLE
🎉 Add overwrite option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ the JSON file's path.
 + `background` (string, optional) - Path to your background
 + `background-color` (string, optional) - Background color (accepts css colors)
 + `icon-size` (number, optional) - Size of all the icons inside the DMG
++ `overwrite-target` (boolean, optional) - Overwrite target if it exists
 + `window` (object, optional) - Window options
     + `position` (object, optional) - Position when opened
         + `x` (number, required) - X position relative to left of the screen

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -76,26 +76,6 @@ module.exports = exports = function (options) {
    **
    **/
 
-  pipeline.addStep('Looking for target', function (next) {
-    fs.writeFile(global.target, '', { flag: 'wx' }, function (err) {
-      if (err && err.code === 'EEXIST') return next(new Error('Target already exists'))
-      if (err) return next(err)
-
-      pipeline.addCleanupStep('unlink-target', 'Removing target image', function (next, hasErrored) {
-        if (hasErrored) {
-          fs.unlink(global.target, next)
-        } else {
-          next(null)
-        }
-      })
-      next(null)
-    })
-  })
-
-  /**
-   **
-   **/
-
   pipeline.addStep('Reading JSON Specification', function (next) {
     if (global.hasSpec) return next.skip()
 
@@ -146,6 +126,26 @@ module.exports = exports = function (options) {
     var message = validateSpec.errors.map(formatError).join(', ')
 
     next(new Error(message))
+  })
+
+  /**
+   **
+   **/
+
+  pipeline.addStep('Looking for target', function (next) {
+    fs.writeFile(global.target, '', { flag: global.opts['overwrite-target'] ? 'w' : 'wx' }, function (err) {
+      if (err && err.code === 'EEXIST') return next(new Error('Target already exists'))
+      if (err) return next(err)
+
+      pipeline.addCleanupStep('unlink-target', 'Removing target image', function (next, hasErrored) {
+        if (hasErrored) {
+          fs.unlink(global.target, next)
+        } else {
+          next(null)
+        }
+      })
+      next(null)
+    })
   })
 
   /**

--- a/schema.json
+++ b/schema.json
@@ -19,6 +19,9 @@
     "icon-size": {
       "type": "integer"
     },
+    "overwrite-target": {
+      "type": "boolean"
+    },
     "window": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
This closes #130 

If overwrite is specified we overwrite the target in the "Looking for target" step. One possible downside of this approach is that if we fail to create the DMG we will still cleanup the previous file. A possible fix to this is to work with a temporary file and rename it to replace the target when we have completed the DMG.