### PR TITLE
Use Node's fs.copyFile, if available.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,8 +1,9 @@
 'use strict'
 
 const execa = require('execa')
+const fs = require('fs')
 const xattr = require('fs-xattr')
-const cpFile = require('cp-file')
+const cpFile = fs.copyFile ? null : require('cp-file')
 const alloc = require('buffer-alloc')
 
 exports.sh = function (prog, args, cb) {
@@ -13,7 +14,7 @@ exports.sh = function (prog, args, cb) {
   })
 }
 
-exports.cp = function (source, target, cb) {
+exports.cp = fs.copyFile || function (source, target, cb) {
   cpFile(source, target).then(function () {
     setImmediate(cb, null)
   }).catch(function (err) {


### PR DESCRIPTION
`cp-file` doesn't seem to work on my system (macOS 10.14.4, Node 11.5.0 from Homebrew). It either throws an error (and trying to get the `stack` from that error results in *another* error being thrown!), or silently fails.

Node's `fs.copyFile` has no such problem. It's not available before Node 8.5.0, and appdmg targets Node ≥ 4, so this PR changes the code so that `fs.copyFile` is used if it is available, and if not, `cp-file` is used as a fallback.