### PR TITLE
Handle unknown background formats gracefully

### DIFF
--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -279,7 +279,7 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Reading background dimensions', function (next) {
-    if (!global.opts.background) return next.skip()
+    if (!global.opts.background || (global.opts.window && global.opts.window.size)) return next.skip()
 
     sizeOf(resolvePath(global.opts.background), function (err, value) {
       if (err) return next(err)

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -282,7 +282,11 @@ module.exports = exports = function (options) {
     if (!global.opts.background || (global.opts.window && global.opts.window.size)) return next.skip()
 
     sizeOf(resolvePath(global.opts.background), function (err, value) {
-      if (err) return next(err)
+      if (err) {
+        const err2 = new Error(`Could not read dimensions of background image: ${err.name}: ${err.message}\nTo avoid this, give an explicit window size (window.size property) in your dmg specification file.`)
+        err2.stack = `${err2.stack}\nCaused by: ${err.stack}`
+        return next(err2)
+      }
 
       global.bkgsize = [value.width, value.height]
       next(null)


### PR DESCRIPTION
One of the image formats supported by Finder for the background image is, somewhat surprisingly, PDF. That's a vector graphics format, so this could be used to make a single background image that scales cleanly to any screen resolution, without having to make a separate `@2x` version of the image.

Problem: appdmg chokes when trying to use a PDF as the background image, because `image-size` doesn't understand that format (and PDF doesn't have a pixel size anyway).

This PR does two things to help with that problem:

* Skip calling `image-size` if a `window.size` is given in the JSON specification file.
* When calling `image-size` fails, give a helpful error message that explains what actually happened (couldn't read the image size) and how to avoid it (by giving a `window.size`).