### PR TITLE
Bump fs-xattr dependency for node12 compatibility. Fix #176

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ds-store": "^0.1.5",
     "execa": "^0.4.0",
     "fs-temp": "^1.0.0",
-    "fs-xattr": "^0.1.14",
+    "fs-xattr": "^0.3.0",
     "image-size": "^0.5.0",
     "is-my-json-valid": "^2.13.1",
     "minimist": "^1.1.3",


### PR DESCRIPTION
just a package.json update for node 12 compatibility.