### PR TITLE
💥 Drop support for Node.js < 8.5.x

### DIFF
--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -163,8 +163,10 @@ module.exports = exports = function (options) {
     async.each(global.files, function (file, cb) {
       const path = resolvePath(file.path)
 
-      fs.exists(path, function (exists) {
-        if (exists) {
+      util.pathExists(path, function (err, exists) {
+        if (err) {
+          cb(err)
+        } else if (exists) {
           cb(null)
         } else {
           cb(new Error(`"${file.path}" not found at: ${path}`))
@@ -262,11 +264,13 @@ module.exports = exports = function (options) {
     function copyPlainBackground (next) {
       const finalPath = path.join(global.bkgdir, path.basename(global.opts.background))
       global.bkgname = path.join('.background', path.basename(global.opts.background))
-      util.cp(absolutePath, finalPath, next)
+      fs.copyFile(absolutePath, finalPath, next)
     }
 
-    fs.exists(retinaPath, function (exists) {
-      if (exists) {
+    util.pathExists(retinaPath, function (err, exists) {
+      if (err) {
+        return next(err)
+      } else if (exists) {
         copyRetinaBackground(next)
       } else {
         copyPlainBackground(next)
@@ -296,7 +300,7 @@ module.exports = exports = function (options) {
   pipeline.addStep('Copying icon', function (next) {
     if (global.opts.icon) {
       const finalPath = path.join(global.temporaryMountPath, '.VolumeIcon.icns')
-      util.cp(resolvePath(global.opts.icon), finalPath, next)
+      fs.copyFile(resolvePath(global.opts.icon), finalPath, next)
     } else {
       next.skip()
     }
@@ -422,10 +426,10 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Signing image', function (next) {
-    var codeSignOptions = global.opts['code-sign']
+    const codeSignOptions = global.opts['code-sign']
     if (codeSignOptions && codeSignOptions['signing-identity']) {
-      var codeSignIdentity = codeSignOptions['signing-identity']
-      var codeSignIdentifier = codeSignOptions['identifier']
+      const codeSignIdentity = codeSignOptions['signing-identity']
+      const codeSignIdentifier = codeSignOptions['identifier']
       util.codesign(codeSignIdentity, codeSignIdentifier, global.target, next)
     } else {
       return next.skip()

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,28 +1,16 @@
 'use strict'
 
 const execa = require('execa')
+const pathExists = require('path-exists')
+const util = require('util')
 const xattr = require('fs-xattr')
-const cpFile = require('cp-file')
-const alloc = require('buffer-alloc')
 
 exports.sh = function (prog, args, cb) {
-  execa(prog, args).then(function (result) {
-    setImmediate(cb, null, result)
-  }).catch(function (err) {
-    setImmediate(cb, err)
-  })
-}
-
-exports.cp = function (source, target, cb) {
-  cpFile(source, target).then(function () {
-    setImmediate(cb, null)
-  }).catch(function (err) {
-    setImmediate(cb, err)
-  })
+  util.callbackify(() => execa(prog, args))(cb)
 }
 
 exports.dusm = function (path, cb) {
-  exports.sh('du', ['-sm', path], function (err, res) {
+  exports.sh('du', ['-sm', path], (err, res) => {
     if (err) return cb(err)
 
     if (res.stderr.length > 0) {
@@ -44,16 +32,20 @@ exports.tiffutil = function (a, b, out, cb) {
 }
 
 exports.seticonflag = function (path, cb) {
-  const buf = alloc(32)
+  const buf = Buffer.alloc(32)
   buf.writeUInt8(4, 8)
-  xattr.set(path, 'com.apple.FinderInfo', buf, cb)
+  util.callbackify(() => xattr.set(path, 'com.apple.FinderInfo', buf))(cb)
 }
 
 exports.codesign = function (identity, identifier, path, cb) {
-  var args = ['--verbose', '--sign', identity]
+  let args = ['--verbose', '--sign', identity]
   if (identifier) {
     args.push('--identifier', identifier)
   }
   args.push(path)
-  exports.sh('codesign', args, function (err) { cb(err) })
+  exports.sh('codesign', args, (err) => cb(err))
+}
+
+exports.pathExists = function (path, cb) {
+  util.callbackify(() => pathExists(path))(cb)
 }

--- a/package.json
+++ b/package.json
@@ -7,20 +7,19 @@
   "repository": "LinusU/node-appdmg",
   "dependencies": {
     "async": "^1.4.2",
-    "buffer-alloc": "^1.1.0",
-    "cp-file": "^3.1.0",
     "ds-store": "^0.1.5",
-    "execa": "^0.4.0",
+    "execa": "^1.0.0",
     "fs-temp": "^1.0.0",
-    "fs-xattr": "^0.1.14",
-    "image-size": "^0.5.0",
-    "is-my-json-valid": "^2.13.1",
+    "fs-xattr": "^0.3.0",
+    "image-size": "^0.7.4",
+    "is-my-json-valid": "^2.20.0",
     "minimist": "^1.1.3",
     "parse-color": "^1.0.0",
+    "path-exists": "^4.0.0",
     "repeat-string": "^1.5.4"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8.5"
   },
   "os": [
     "darwin"
@@ -30,8 +29,8 @@
   },
   "devDependencies": {
     "capture-window": "^0.1.3",
-    "looks-same": "^2.1.0",
-    "mocha": "^2.2.5",
-    "standard": "^7.0.1"
+    "looks-same": "^7.2.1",
+    "mocha": "^6.1.4",
+    "standard": "^12.0.1"
   }
 }

--- a/test/api.js
+++ b/test/api.js
@@ -23,8 +23,8 @@ function runAppdmg (opts, verify, cb) {
 
   ee.on('finish', function () {
     try {
-      assert.equal(progressCalled, STEPS * 2)
-      assert.equal(imageFormat(opts.target), verify.format)
+      assert.strictEqual(progressCalled, STEPS * 2)
+      assert.strictEqual(imageFormat(opts.target), verify.format)
     } catch (err) {
       return cb(err)
     }

--- a/test/lib/visually-verify-image.js
+++ b/test/lib/visually-verify-image.js
@@ -35,7 +35,7 @@ function captureAndVerify (title, expectedPath, cb) {
 
     // If the actual size is scaled by two, use the retina image.
     if (actualSize.width === expectedSize.width * 2 && actualSize.height === expectedSize.height * 2) {
-      expectedPath = expectedPath.replace(/(\.[^\.]*)$/, '@2x$1')
+      expectedPath = expectedPath.replace(/(\.[^.]*)$/, '@2x$1')
     }
 
     looksSame(pngPath, expectedPath, toleranceOpts, function (err1, ok) {


### PR DESCRIPTION
closes #173, closes #178, fixes #176, fixes #177, fixes #172

> Migration Guide:
> 
> Upgrade to Node.js 8.5.0 or newer.

Will add some more commits to slowly move the internal code base towards using promises, but want to get this out the door quickly to address Node.js 12.x support ☺️ 