### PR TITLE
Add support for attaching a license agreement to the DMG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ the JSON file's path.
   "contents": [
     { "x": 448, "y": 344, "type": "link", "path": "/Applications" },
     { "x": 192, "y": 344, "type": "file", "path": "TestApp.app" }
+  ],
+  "license": [
+    {
+      "body": [
+        {
+          "lang": "en-US",
+          "text": "This is an example license agreement."
+        },
+        {
+          "lang": "fr-FR",
+          "text": "Ceci est un exemple de contrat de licence."
+        }
+      ]
+    }
   ]
 }
 ```
@@ -76,6 +90,29 @@ the JSON file's path.
       - `position` - Positions a present file
     - `path` (string, required) - Path to the file
     - `name` (string, optional) - Name of the file within the DMG
+- `license` (object, optional) - License agreement to add to the DMG ([see detailed documentation](https://github.com/argv-minus-one/dmg-license/blob/master/docs/License%20Specifications.md))
+  - `body` (array[object], required) - Localized license texts
+    - `lang` (string or integer or array[string or integer], required) - Language(s) of this localization of the license agreement
+      - Can be an [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag), a classic Mac OS [language code](https://github.com/phracker/MacOSX-SDKs/blob/aea47c83334af9c27dc57c49ca268723ef5e6349/MacOSX10.6.sdk/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/CarbonCore.framework/Versions/A/Headers/Script.h#L285), or an array of them
+      - See [full list of supported language tags](https://github.com/argv-minus-one/dmg-license/blob/master/docs/Supported%20Language%20Tags.md)
+    - `text` or `file` (string, required) - Text of the license agreement in the given `lang`, or the path to the file containing the text
+    - `charset` (string, optional, default: UTF-8) - Character set of the `file`
+    - `type` (enum[string], optional)
+      - `plain` - License body is plain text
+      - `rtf` - License body is RTF
+      - If omitted, this defaults to `rtf` if `file` ends with `.rtf`, otherwise `plain`
+  - `labels` (array[object], optional) - Localized label strings for the license agreement window
+    - `lang` (string or integer or array[string or integer], required) - Language(s) of this label set
+    - `localizedName` (string, optional) - Localized name of this language
+    - `agree` (string, required) - “Agree” button label
+    - `disagree` (string, required) - “Disagree” button label
+    - `print` (string, required) - “Print” button label
+    - `save` (string, required) - “Save” button label
+    - `message` (string, required) - Brief instructions for the user
+  - `rawLabels` (array[object], optional) - Localized label strings for the license agreement window, in [raw binary format](https://github.com/argv-minus-one/dmg-license/blob/master/docs/Raw%20labels%20format.md)
+    - `lang` (string or integer or array[string or integer], required) - Language(s) of this label set
+    - `file` (string, required) - File containing the label strings
+  - `defaultLang` (string or integer, optional, default: first `lang` of first `body`) - Default language to use if there is no license localization in the user's preferred language
 - `code-sign` (object, optional) - Options for codesigning the DMG
   - `signing-identity` (string, required) - The identity with which to sign the resulting DMG
   - `identifier` (string, optional) - Explicitly set the unique identifier string that is embedded in code signatures

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 
 const async = require('async')
+const dmgLicense = require('dmg-license')
 const DSStore = require('ds-store')
 const sizeOf = require('image-size')
 const validator = require('is-my-json-valid')
@@ -13,10 +14,15 @@ const util = require('./util')
 const hdiutil = require('./hdiutil')
 const Pipeline = require('./pipeline')
 const schema = require('../schema')
+const licenseSchema = require('dmg-license/schema.json')
 
 const validateSpec = validator(schema, {
   formats: {
     'css-color': (text) => Boolean(parseColor(text).rgb)
+  },
+  jsonPointers: true,
+  schemas: {
+    'https://github.com/argv-minus-one/dmg-license/raw/master/schema.json': licenseSchema
   }
 })
 
@@ -419,6 +425,24 @@ module.exports = exports = function (options) {
     const format = (global.opts.format || 'UDZO')
 
     hdiutil.convert(global.temporaryImagePath, format, global.target, next)
+  })
+
+  /**
+   **
+   **/
+
+  pipeline.addStep('Applying license to image', function (next) {
+    if (!global.opts.license) {
+      return next.skip()
+    }
+
+    dmgLicense.dmgLicenseFromJSON(global.target, global.opts.license, {
+      onNonFatalError: function (err) {
+        pipeline.emit('warning', err)
+      },
+      resolvePath: resolvePath,
+      specSourceURL: '#/license'
+    }).then(next, next)
   })
 
   /**

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "LinusU/node-appdmg",
   "dependencies": {
     "async": "^1.4.2",
-    "dmg-license": "^1.0.4",
+    "dmg-license": "^1.0.5",
     "ds-store": "^0.1.5",
     "execa": "^1.0.0",
     "fs-temp": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "LinusU/node-appdmg",
   "dependencies": {
     "async": "^1.4.2",
-    "dmg-license": "^1.0.3",
+    "dmg-license": "^1.0.4",
     "ds-store": "^0.1.5",
     "execa": "^1.0.0",
     "fs-temp": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "LinusU/node-appdmg",
   "dependencies": {
     "async": "^1.4.2",
+    "dmg-license": "^1.0.3",
     "ds-store": "^0.1.5",
     "execa": "^1.0.0",
     "fs-temp": "^1.0.0",
@@ -31,6 +32,8 @@
     "capture-window": "^0.1.3",
     "looks-same": "^7.2.1",
     "mocha": "^6.1.4",
+    "plist": "^3.0.1",
+    "read-xml": "^3.0.0",
     "standard": "^12.0.1"
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -112,6 +112,9 @@
       "required": [
         "signing-identity"
       ]
+    },
+    "license": {
+      "type": "object"
     }
   },
   "required": [


### PR DESCRIPTION
This PR adds a way to attach a license agreement to the generated DMG, fixing issue #111. It uses [argv-minus-one/dmg-license](https://github.com/argv-minus-one/dmg-license) to do the work.