### PR TITLE
Catch pipeline errors during tests

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -21,6 +21,8 @@ function runAppdmg (opts, verify, cb) {
     progressCalled++
   })
 
+  ee.on('error', cb)
+
   ee.on('finish', function () {
     try {
       assert.strictEqual(progressCalled, STEPS * 2)


### PR DESCRIPTION
Currently, if the appdmg pipeline errors out during one of the tests, the error is swallowed and the test simply times out after 60 seconds. This trivial PR fixes that.