### PR TITLE
fix(hdiutil): don't check the error message when "Resource busy" (EBUSY, 16) occurs

### DIFF
--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -64,7 +64,7 @@ exports.detach = function (path, cb) {
   const args = ['detach', path]
 
   util.sh('hdiutil', args, function (err) {
-    if (err && err.exitCode === 16 && /Resource busy/.test(err.stderr)) {
+    if (err && err.exitCode === 16) {
       setTimeout(function () {
         util.sh('hdiutil', args, (err) => cb(err))
       }, 1000)


### PR DESCRIPTION
Related to #190 .

Hi. Please see the commit message for details.

The non-linear commit history is on purpose because I want to express my original intentions. Please feel free to squash them.
