### PR TITLE
Updated async to 3.2.2. Fixes Prototype Pollution vulnerability (#208)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": "bin/appdmg.js",
   "repository": "LinusU/node-appdmg",
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "^3.2.2",
     "ds-store": "^0.1.5",
     "execa": "^1.0.0",
     "fs-temp": "^1.0.0",


### PR DESCRIPTION
Fixes #208.

Updated async to 3.2.2 due to a known Prototype Pollution vulnerability. You may update to 3.2.3 (latest) if necessary.