### PR TITLE
Update hdiutil.js

### DIFF
--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -66,7 +66,7 @@ exports.detach = function (path, cb) {
   let attempts = 0
   function attemptDetach (err) {
     attempts += 1
-    if (err && (err.exitCode === 16 || err.code === 16) && attempts <= 5) {
+    if (err && (err.exitCode === 16 || err.code === 16) && attempts <= 8) {
       setTimeout(function () {
         util.sh('hdiutil', args, attemptDetach)
       }, 1000 * Math.pow(2, attempts - 1))


### PR DESCRIPTION
When creating a DMG with electron-installer-dmg and electron-builder, I encountered the following error due to timeout waiting for volume detach to be successful. By increasing the attempts from 5 to 8, the build is successful. The build is done using macOS Monterey (12.6) with Apple M1 Max. Maybe 10 is a better number for older Mac?

    at makeError (/.../node_modules/execa/index.js:174:9)
    at /.../node_modules/execa/index.js:278:16
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
  code: 16,
  stdout: '',
  stderr: `hdiutil: couldn't unmount "disk6" - Resource busy\n`,
  failed: true,
  signal: null,
  cmd: 'hdiutil detach /Volumes/MyProjectName,
  timedOut: false,
  killed: false
}