### PR TITLE
Add support for ULMO format (LZMA compression)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ the JSON file's path.
     - `UDZO` - UDIF zlib-compressed image
     - `UDBZ` - UDIF bzip2-compressed image (OS X 10.4+ only)
     - `ULFO` - UDIF lzfse-compressed image (OS X 10.11+ only)
+    - `ULMO` - UDIF lzma-compressed image (macOS 10.15+ only)
 - `contents` (array[object], required) - This is the contents of your DMG.
     - `x` (number, required) - X position relative to icon center
     - `y` (number, required) - Y position relative to icon center

--- a/schema.json
+++ b/schema.json
@@ -62,6 +62,7 @@
         "UDCO",
         "UDZO",
         "ULFO",
+        "ULMO",
         "UDBZ"
       ]
     },


### PR DESCRIPTION
This is a simple change to add ULMO format option (requires macOS 10.15+) in the json schema specification. I tested this locally by creating a lzma based dmg using appdmg.

For additional context, lzma has a high level of compression (e.g. for one of the chromium based apps I tested I see a difference from 240 MB (lzfse) vs 185 MB (lzma)) with a slower extraction time, but often the file size savings lzma produces against the decompression time are quite favorable.