### PR TITLE
Add support for creating APFS disk images

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ the JSON file's path.
     - `UDZO` - UDIF zlib-compressed image
     - `UDBZ` - UDIF bzip2-compressed image (OS X 10.4+ only)
     - `ULFO` - UDIF lzfse-compressed image (OS X 10.11+ only)
+- `filesystem` (enum[string], optional) - Disk image filesystem
+    - `HFS+`
+    - `APFS` (macOS 10.13+ only)
 - `contents` (array[object], required) - This is the contents of your DMG.
     - `x` (number, required) - X position relative to icon center
     - `y` (number, required) - Y position relative to icon center

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -206,7 +206,7 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Creating temporary image', function (next) {
-    hdiutil.create(global.opts.title, `${global.megabytes}m`, function (err, temporaryImagePath) {
+    hdiutil.create(global.opts.title, `${global.megabytes}m`, global.opts.filesystem, function (err, temporaryImagePath) {
       if (err) return next(err)
 
       pipeline.addCleanupStep('unlink-temporary-image', 'Removing temporary image', function (next) {
@@ -396,15 +396,20 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Blessing image', function (next) {
-    const args = [
-      '--folder', global.temporaryMountPath
-    ]
+    // Blessing does not work for APFS disk images
+    if (global.opts.filesystem != "APFS") {
+      const args = [
+          '--folder', global.temporaryMountPath
+        ]
 
-    if (os.arch() !== 'arm64') {
-      args.push('--openfolder', global.temporaryMountPath)
-    }
+        if (os.arch() !== 'arm64') {
+          args.push('--openfolder', global.temporaryMountPath)
+        }
 
-    util.sh('bless', args, next)
+        util.sh('bless', args, next)
+      } else {
+        next.skip()
+      }
   })
 
   /**

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -399,17 +399,17 @@ module.exports = exports = function (options) {
     // Blessing does not work for APFS disk images
     if (global.opts.filesystem != "APFS") {
       const args = [
-          '--folder', global.temporaryMountPath
-        ]
+        '--folder', global.temporaryMountPath
+      ]
 
-        if (os.arch() !== 'arm64') {
-          args.push('--openfolder', global.temporaryMountPath)
-        }
-
-        util.sh('bless', args, next)
-      } else {
-        next.skip()
+      if (os.arch() !== 'arm64') {
+        args.push('--openfolder', global.temporaryMountPath)
       }
+
+      util.sh('bless', args, next)
+    } else {
+      next.skip()
+    }
   })
 
   /**

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -29,7 +29,7 @@ exports.create = function (volname, size, filesystem, cb) {
     const args = [
       'create', outname,
       '-ov',
-      '-fs', filesystem,
+      '-fs', filesystem || 'HFS+',
       '-size', size,
       '-volname', volname
     ]

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs')
 const temp = require('fs-temp')
-const crypto = require('crypto')
+const randomPath = require('random-path')
 const util = require('./util')
 
 exports.convert = function (source, format, target, cb) {
@@ -44,7 +44,7 @@ exports.create = function (volname, size, filesystem, cb) {
 }
 
 exports.attach = function (path, cb) {
-  const mountpoint = '/Volumes/' + crypto.randomUUID()
+  const mountpoint = randomPath('/Volumes', '%s')
   const args = [
     'attach', path,
     '-nobrowse',

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -43,8 +43,6 @@ exports.create = function (volname, size, filesystem, cb) {
 }
 
 exports.attach = function (path, cb) {
-
-
   const args = [
     'attach', path,
     '-nobrowse',

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -44,7 +44,11 @@ exports.create = function (volname, size, filesystem, cb) {
 }
 
 exports.attach = function (path, cb) {
-  const mountpoint = randomPath('/Volumes', '%s')
+  var mountpoint = ""
+  do {
+    mountpoint = randomPath('/Volumes', '%s')
+  } while (fs.existsSync(mountpoint))
+
   const args = [
     'attach', path,
     '-nobrowse',

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -2,7 +2,6 @@
 
 const fs = require('fs')
 const temp = require('fs-temp')
-const randomPath = require('random-path')
 const util = require('./util')
 
 exports.convert = function (source, format, target, cb) {
@@ -44,24 +43,22 @@ exports.create = function (volname, size, filesystem, cb) {
 }
 
 exports.attach = function (path, cb) {
-  var mountpoint = ""
-  do {
-    mountpoint = randomPath('/Volumes', '%s')
-  } while (fs.existsSync(mountpoint))
+
 
   const args = [
     'attach', path,
     '-nobrowse',
     '-noverify',
-    '-noautoopen',
-    '-mountpoint',
-    mountpoint
+    '-noautoopen'
   ]
 
   util.sh('hdiutil', args, function (err, res) {
     if (err) return cb(err)
 
-    cb(null, mountpoint)
+    const m = /\s+(\/Volumes\/.+)$/m.exec(res.stdout)
+    if (m === null) return cb(new Error('Failed to mount image'))
+
+    cb(null, m[1])
   })
 }
 

--- a/lib/hdiutil.js
+++ b/lib/hdiutil.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const temp = require('fs-temp')
+const crypto = require('crypto')
 const util = require('./util')
 
 exports.convert = function (source, format, target, cb) {
@@ -22,14 +23,14 @@ exports.convert = function (source, format, target, cb) {
   })
 }
 
-exports.create = function (volname, size, cb) {
+exports.create = function (volname, size, filesystem, cb) {
   temp.template('%s.dmg').writeFile('', function (err, outname) {
     if (err) return cb(err)
 
     const args = [
       'create', outname,
       '-ov',
-      '-fs', 'HFS+',
+      '-fs', filesystem,
       '-size', size,
       '-volname', volname
     ]
@@ -43,20 +44,20 @@ exports.create = function (volname, size, cb) {
 }
 
 exports.attach = function (path, cb) {
+  const mountpoint = '/Volumes/' + crypto.randomUUID()
   const args = [
     'attach', path,
     '-nobrowse',
     '-noverify',
-    '-noautoopen'
+    '-noautoopen',
+    '-mountpoint',
+    mountpoint
   ]
 
   util.sh('hdiutil', args, function (err, res) {
     if (err) return cb(err)
 
-    const m = /Apple_HFS\s+(.*)\s*$/.exec(res.stdout)
-    if (m === null) return cb(new Error('Failed to mount image'))
-
-    cb(null, m[1])
+    cb(null, mountpoint)
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "minimist": "^1.1.3",
     "parse-color": "^1.0.0",
     "path-exists": "^4.0.0",
-    "random-path": "^0.1.2",
     "repeat-string": "^1.5.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "minimist": "^1.1.3",
     "parse-color": "^1.0.0",
     "path-exists": "^4.0.0",
+    "random-path": "^0.1.2",
     "repeat-string": "^1.5.4"
   },
   "engines": {

--- a/schema.json
+++ b/schema.json
@@ -65,6 +65,13 @@
         "UDBZ"
       ]
     },
+    "filesystem": {
+      "type": "string",
+      "enum": [
+        "HFS+",
+        "APFS"
+      ]
+    },
     "contents": {
       "type": "array",
       "items": {


### PR DESCRIPTION
This adds support for creating APFS disk images which require macOS 10.13 or newer.

I tested this change locally with appdmg and verified generating both HFS+ and APFS disk images still work. I slightly changed the attach code to specify the mountpoint instead of fetching it from stdout for this change.

The use case is not wanting to support older OS systems for app disk images and not wanting to use HFS+, which while testing I've seen have worse performance for extraction*. Simply put, APFS is a more modern filesystem.

(\*tested on macOS 13.0.1 with an app like VLC.app 3.0.18 (arm64; ~134 MB) under heavier compression using ULMO or UDBZ with Finder** and have seen ~2x performance difference; e.g. 3-4 sec vs 6-8 sec)
(**hdiutil is not measured because its disk image mounting implementation is slower as of current writing and doesn't well model a user using the dmg)