### PR TITLE
fix: bless on Rosetta capable environments(arm64)

### DIFF
--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -406,8 +406,8 @@ module.exports = exports = function (options) {
       (error, stdout, stderr) => {
 
         const result = stdout.trim();
-        if (!error && !stderr && result != null) {
-          isRosetta = result == 1 || result == 0;
+        if (!error && !stderr && result != null && result !== '') {
+          isRosetta = true;
         }
 
         next()

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -4,8 +4,6 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
-const execFile = require('child_process').execFile
-
 const async = require('async')
 const DSStore = require('ds-store')
 const sizeOf = require('image-size')
@@ -400,19 +398,20 @@ module.exports = exports = function (options) {
    **/
 
   pipeline.addStep('Checking if running under Rosetta', function (next) {
-    execFile(
+    util.sh(
       'sysctl',
       ['-ni', 'sysctl.proc_translated'],
-      (error, stdout, stderr) => {
-
-        const result = stdout.trim();
-        if (!error && !stderr && result != null && result !== '') {
+      (error, result) => {
+        if (
+          error == null &&
+          result.errno === 0 &&
+          result.stdout !== ''
+        ) {
           isRosetta = true;
         }
 
-        next()
-      }
-    );
+        next();
+    });
   });
 
   /**

--- a/lib/appdmg.js
+++ b/lib/appdmg.js
@@ -4,6 +4,8 @@ const fs = require('fs')
 const os = require('os')
 const path = require('path')
 
+const execFile = require('child_process').execFile
+
 const async = require('async')
 const DSStore = require('ds-store')
 const sizeOf = require('image-size')
@@ -68,6 +70,8 @@ module.exports = exports = function (options) {
 
   const global = parseOptions(options)
   const resolvePath = (to) => path.resolve(global.resolveBase, to)
+
+  let isRosetta = false;
 
   const pipeline = new Pipeline()
 
@@ -395,6 +399,26 @@ module.exports = exports = function (options) {
    **
    **/
 
+  pipeline.addStep('Checking if running under Rosetta', function (next) {
+    execFile(
+      'sysctl',
+      ['-ni', 'sysctl.proc_translated'],
+      (error, stdout, stderr) => {
+
+        const result = stdout.trim();
+        if (!error && !stderr && result != null) {
+          isRosetta = result == 1 || result == 0;
+        }
+
+        next()
+      }
+    );
+  });
+
+  /**
+   **
+   **/
+
   pipeline.addStep('Blessing image', function (next) {
     // Blessing does not work for APFS disk images
     if (global.opts.filesystem !== 'APFS') {
@@ -402,7 +426,7 @@ module.exports = exports = function (options) {
         '--folder', global.temporaryMountPath
       ]
 
-      if (os.arch() !== 'arm64') {
+      if (!isRosetta && os.arch() !== 'arm64') {
         args.push('--openfolder', global.temporaryMountPath)
       }
 


### PR DESCRIPTION
Issue:
\- bless doesn't support `--openfolder` for Apple Silicon based architectures.
\- With Rosetta transcoding the current check of `os.arch()` returns `x86`; this is why #205 did not solve the issue.
\- Other node-native potential checks also fail to identify Apple Silicon environments

Fix:
\- Check `sysctl.proc_translated` and if it has a value assume the machine is Rosetta-capable and thus Apple Silicon

Implementation:
\- use `sysctl` command to retrieve the value of `sysctl.proc_translated`. If a value is returned it can be assumed the machine is Rosetta-capable.
\- Do not use `--openfolder` when Rosetta-capability has been assumed.

Tests:
\- MacBook Air, 2020 (M1)
\- MacBook Pro, 2021 (M1 Pro)

Addresses:
#216, #218, #219, #239
