### PR TITLE
Upgrade `capture-window` to v0.2.0 to fix issue with old `fs-temp` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "appdmg": "bin/appdmg.js"
       },
       "devDependencies": {
-        "capture-window": "^0.1.3",
+        "capture-window": "^0.2.0",
         "looks-same": "^7.2.1",
         "mocha": "^6.1.4",
         "standard": "^12.0.1"
@@ -328,21 +328,17 @@
       }
     },
     "node_modules/capture-window": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/capture-window/-/capture-window-0.1.3.tgz",
-      "integrity": "sha512-eDf+rIy4M1CH9HJZY5Vl5Mx4nKb+ZXt3bkNpNtHju88XvjjzjDw9c/SVpGFJ8OPuGnzvGwigBKCOZ3gsv8XSVQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/capture-window/-/capture-window-0.2.0.tgz",
+      "integrity": "sha512-0iZCnNvrxfS2qV9S9TLBq1iHHN9FZDknOGAG4Uf0K+1WLGgdEfpZKfm3N1ahEdz/HF8DISt7GMToHMM4SrN/Dg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "fs-temp": "^0.1.1",
-        "nan": "^2.0.5"
+        "fs-temp": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
-    },
-    "node_modules/capture-window/node_modules/fs-temp": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-0.1.3.tgz",
-      "integrity": "sha512-sVCj7s7jLs+SSbNXSUL9xKYm/QNL2d7x6NQdirqnN49uXl2akPpWB2ENrh+zLad4j6RQo50/OY0tEq/8KlVD5w==",
-      "dev": true
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -3843,21 +3839,12 @@
       "dev": true
     },
     "capture-window": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/capture-window/-/capture-window-0.1.3.tgz",
-      "integrity": "sha512-eDf+rIy4M1CH9HJZY5Vl5Mx4nKb+ZXt3bkNpNtHju88XvjjzjDw9c/SVpGFJ8OPuGnzvGwigBKCOZ3gsv8XSVQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/capture-window/-/capture-window-0.2.0.tgz",
+      "integrity": "sha512-0iZCnNvrxfS2qV9S9TLBq1iHHN9FZDknOGAG4Uf0K+1WLGgdEfpZKfm3N1ahEdz/HF8DISt7GMToHMM4SrN/Dg==",
       "dev": true,
       "requires": {
-        "fs-temp": "^0.1.1",
-        "nan": "^2.0.5"
-      },
-      "dependencies": {
-        "fs-temp": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-0.1.3.tgz",
-          "integrity": "sha512-sVCj7s7jLs+SSbNXSUL9xKYm/QNL2d7x6NQdirqnN49uXl2akPpWB2ENrh+zLad4j6RQo50/OY0tEq/8KlVD5w==",
-          "dev": true
-        }
+        "fs-temp": "^1.2.1"
       }
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "standard && mocha -b"
   },
   "devDependencies": {
-    "capture-window": "^0.1.3",
+    "capture-window": "^0.2.0",
     "looks-same": "^7.2.1",
     "mocha": "^6.1.4",
     "standard": "^12.0.1"

--- a/test/lib/visually-verify-image.js
+++ b/test/lib/visually-verify-image.js
@@ -27,9 +27,11 @@ function retry (fn, cb) {
 }
 
 function captureAndVerify (title, expectedPath, cb) {
-  captureWindow('Finder', title, function (err, pngPath) {
-    if (err) return cb(err)
-
+  const captureWindowPromise = captureWindow('Finder', title)
+  captureWindowPromise.catch(function (err) {
+    cb(err)
+  })
+  captureWindowPromise.then(function (pngPath) {
     const actualSize = sizeOf(pngPath)
     const expectedSize = sizeOf(expectedPath)
 
@@ -51,9 +53,11 @@ function captureAndVerify (title, expectedPath, cb) {
 }
 
 function captureAndSaveDiff (title, expectedPath, cb) {
-  captureWindow('Finder', title, function (err, pngPath) {
-    if (err) return cb(err)
-
+  const captureWindowPromise = captureWindow('Finder', title)
+  captureWindowPromise.catch(function (err) {
+    cb(err)
+  })
+  captureWindowPromise.then(function (pngPath) {
     const opts = Object.assign({
       reference: expectedPath,
       current: pngPath,


### PR DESCRIPTION
This enables the `appdmg` to work correctly on modern NodeJS runtimes. The `fs-temp` dependency requires this fix https://github.com/LinusU/fs-temp/pull/3.

The `capture-window` v0.2.0 includes fixed `fs-temp` and also changes the `captureWindow` function to be async.